### PR TITLE
Add generall call for participation

### DIFF
--- a/_includes/css/sotm.css
+++ b/_includes/css/sotm.css
@@ -966,6 +966,10 @@ p img.bio-pic {
   border-color: #C7C7F9;
 }
 
+.trackicon#track-education:before {
+  border-color: #FF9EB1;
+}
+
 .trackicon#track-academic:before {
   border-color: #dddddd;
 }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
           <div class="col3 pad4x hide-mobile">
           </div>
           <nav class="col3 pad2x">
-            <!--<a class="block" href="{{site.baseurl}}/calls/general"block>Call for Participation</a>-->
+            <a class="block" href="{{site.baseurl}}/calls/general" block>Call for Participation</a>
             <!--<a class="block" href="https://lists.openstreetmap.org/pipermail/science/2021-February/000093.html">Call for applications for the Scientific Committee</a>-->
             <!--<a class="block" href="{{site.baseurl}}/calls/academic">Call for Scientific Abstracts</a>-->
             <!--<a class="block" href="{{site.baseurl}}/calls/posters">Call for Posters</a>-->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,9 +15,9 @@
                     <li class="hidden">
                         <a class="page-scroll" href="#page-top"></a>
                     </li>
-                    <!--<li>
+                    <li>
                         <a class="{% if page.url contains '/calls/general' %}active{% endif %}" href="{{site.baseurl}}/calls/general">Call for Participation</a>
-                    </li>-->
+                    </li>
                     <!--<li>
                         <a class="{% if page.url contains '/calls/academic' %}active{% endif %}" href="{{site.baseurl}}/calls/academic">Call for Scientific Abstracts</a>
                     </li>-->

--- a/calls/general.md
+++ b/calls/general.md
@@ -1,0 +1,205 @@
+---
+layout: page-with-toc
+title: "Call for Participation and Submission Guidelines"
+titlecontent: ""
+headings: "tracks,submission,other-submission,recommendations,rating,language,publication,committee,timeline_deadlines,submit"
+---
+
+## Call for Participation {#call}
+
+
+The State of the Map (SotM) conference is the annual OpenStreetMap (OSM) conference run by the [OpenStreetMap Foundation (OSMF)](https://osmfoundation.org/). It is organised by the [SotM Working Group](https://osmfoundation.org/wiki/StateoftheMap_Organizing_Committee), a team of volunteers. SotM 2025 will again be a hybrid event, held in person in Manila, Philippines and online!
+
+
+State of the Map is intended as an opportunity for the OpenStreetMap community to get to know each other, both personally and regarding their work in OpenStreetMap. We want to offer a programme that covers all topics relevant to OpenStreetMap. Sharing OpenStreetMap knowledge is the essence of SotM. Apart from presentations, we value the interaction between listeners and speakers, so we want to create an environment that boosts creative, critical and healthy discussions, including contentious topics. This year we meet in the vibrant city of Manila in the Philippines. We hope that many of you join us there. At the same time, we recognise that many people may not be able to travel due to personal reasons or governmental restrictions. Therefore, we intend to share the programme virtually as well and give the virtual visitors the opportunity to participate and interact.
+
+We would love to see your submission for one or more of these tracks:
+
+* OSM Basics
+* Community and Foundation
+* Mapping
+* Cartography
+* Software Development
+* Data Analysis & Data Model
+* User Experiences
+* Education
+
+## Tracks {#tracks}
+
+Don’t worry too much about the track categories. They are mainly there to give you an idea on what kind of talks we are looking for and to help us organise the conference. If you find it difficult to select the right track for your talk, choose the one that fits best.
+
+### OSM Basics {#track-basics}
+{: .trackicon}
+
+OSM has grown a lot. Many newcomers or "newbies" have a great thirst for knowledge in areas that may seem uninteresting and basic to experienced contributors. We want you, the expert, to pass on your knowledge to the next generation of community members. Considering we have a variety of participants from across the globe, these talks should be easy to follow and understand. Please note the approximate level of previous knowledge that is required for the participants in your submission.
+
+Examples for this kind of talk are: Explaining the OSM data model. Introduction to OSM Editors or cartography tools. Working with OSM data using the Overpass API. How to render a map? How to print a map?
+
+### Community and Foundation {#track-community}
+{: .trackicon}
+
+Want to recount your experiences while building a community? Or talk about the vision of the OSMF? Or maybe discuss the strategy of the Board? Then this is the right track for you. Reflections on community diversity and questions on etiquette are also suitable. Other possible topics include reasons to become an OSMF member, working group experiences, and everything related to the OSMF, the OSM communities and local chapters.
+
+### Mapping {#track-mapping}
+{: .trackicon}
+
+This track is all about mapping, surveying, data collection, tagging; tips and reflections on OSM editors, or new editor features; reflections on automated mapping, organised editing and imports.
+
+### Cartography {#track-cartography}
+{: .trackicon}
+
+Possible topics can include cartography and data visualisation, rendering raster and vector maps, map styles, CartoCSS, MapLibre, maps with QGIS, printing maps and more. All your ideas on how to create a beautiful, fun, quirky and out-of-this-world map! The track also provides a space to present your artistic and creative projects that use OSM data or themes to create clothing, jewellery, 3D printed objects, engravings, visualizations, computer, mobile or board games, virtual worlds, augmented reality, flyers, postcards, etc.
+
+### Software Development {#track-software}
+{: .trackicon}
+
+This track awaits talks by or for developers of applications that make use of OSM data: OSM editors, (vector) tile servers, geocoding, routing, navigation, editor layer indices; tips and tricks with new PostGIS features, or new features of other tools and applications.
+
+### Data Analysis and Data Model {#track-data}
+{: .trackicon}
+
+This track is dedicated to the OSM data itself: Analysis of the OSM data quality; reflections about enhancing the data model; or discussing the way the OSM data is accessed through the API. Also submissions about the use of AI with OSM data are welcome in this track.
+
+### User Experiences {#track-experiences}
+{: .trackicon}
+
+This track is all about the usage of OSM. Examples are how OSM is used in governments, public transport, humanitarian response, and scientific contexts, among others. You can also present citizen projects that are using OSM data to understand and manage their environment.
+
+### Education {#track-education}
+{: .trackicon}
+
+This new track is intended for sessions about the use of OSM in an educational context, like geography courses, using OSM as an educational tool in classrooms, how to use OSM when teaching GIS tools, introducing students to contributing to OSM, etc.
+
+## Submission Types {#submission}
+
+For most submission types, you may choose whether you attend in person or participate virtually. We will try to make all events available for online and offline attendance. Exceptions are noted below. Please keep in mind that the conference will take place in the PHT (Philippine Time) time zone (UTC+8). When scheduling sessions, we will try to accommodate to the time zone of remote speakers, but we are restricted to the usual conference hours between 9am and 6pm local time (i.e. PHT).
+
+### Talk (20 minutes) {#submission-talk}
+
+Classic talk of about 20 minutes for the talk itself followed by a short question and answer session. This is the preferred submission type. Talks can either be held in-person at the conference or, if you cannot attend, you may submit a pre-recorded talk. The Q&A part of the talk is always live. Virtual speakers will join via a video call. That means that even with a pre-recorded video, you need to be available during your talk.
+
+### Extended Talk (40 minutes) {#submission-talk}
+
+An extended talk has 40 minutes for the talk and 15 minutes for questions. These are for topics you want to explore in more depth. The same rules as for classic talks apply. You should outline why your talk needs more time.
+
+### Workshop (60–90 minutes) {#submission-workshop}
+
+Workshops are sessions in which the participants are actively involved, for example by following some steps on their own devices. We welcome workshops that cover basic beginner's topics as well as innovative technologies.
+
+Please communicate the equipment that participants need to bring in order to participate in your workshop. Also ensure that your participants shouldn't be told to create an account at a commercial platform or a platform with user tracking. Or if so, communicate that in a clear way in your submission and provide guest accounts for your participants.
+
+Workshops will be held either in-person or virtually, not with a mixed audience. If you want to offer the workshop for both audiences, you are welcome to hold it twice. For virtual workshops, we will provide video conference rooms. Online workshops will have a limited number of places to ensure a successful session.
+
+### Panel Discussion (60-90 minutes) {#submission-panel}
+
+Panels are for hot, controversial discussions around the OSM community, mapping and data. Topics may cover for example diversity, legal questions or the future of the data model. You should outline the format on how you intend to organise the discussion and make sure to invite the key players for the discussion. Panels must be held in person with all participants present at the conference. We welcome panels that include the audience. Just keep in mind that questions come from virtual and in-person participants. A designated moderator is therefore strongly recommended.
+
+### Other {#submission-other}
+
+Your submission does not fit into any of these submission types? Please get in touch with the programme committee via email ([program-sotm@openstreetmap.org](mailto:program-sotm@openstreetmap.org)) before the end of the call for participation.
+
+
+## Spontaneous Sessions {#other-submission}
+
+We plan to provide space for sessions which cannot be submitted in advance. Details will be announced before the conference.
+
+### Lightning Talk {#submission-lightning_talk}
+
+Lightning talks will be short 5 minute talks. There will be some spaces for last-minute in-person talks with an on-site sign-up on a whiteboard.
+
+### Birds of a Feather {#submission-bof}
+
+Birds of a Feather (BOF) sessions are informal, spontaneous discussion rounds centred around a specific topic. It is not possible to submit a BOF session in advance. BOFs will usually be held in-person only.
+
+### Free Spaces {#submission-free_spaces}
+
+We will try to provide free spaces to meet or just chitchat for working groups, local chapters, local groups, user groups, etc.
+
+## Submission Recommendations {#recommendations}
+
+Based on our past experience, we have some recommendations for your submission:
+
+* Try to come up with a succinct title for your talk. You can add more details to the abstract and the talk description.
+* Avoid copy-pasting of an existing project description. These are often lengthy and don't give a lot of information about the actual contents of your talk.
+* Mention what your talk will be about and the topics you plan to cover.
+* If your session is actually connected to OpenStreetMap but this isn't obvious, make sure to explain how your talk is related to OSM.
+* You're welcome to use generative AI like ChatGPT to improve your abstract or talk description, but you must mention this in the organiser notes of your submission.
+
+When submitting or confirming your talk, you will be able to declare your availabilities. When using this (which is optional), please be aware that this uses the local PHT time zone (UTC+8). Also be aware that this is _not_ intended to choose the precise time when you want to hold your session, but to inform us that you're not available on a specific conference (half-) day or so because you e.g. arrive late, leave early, have some sort of appointment, etc. So if you use this, the time ranges you choose should cover the majority of the three conference days.
+
+## Rating Criteria {#rating}
+
+In rating submissions, we will apply the following criteria:
+
+* OSM as the subject: A submission where OSM is the main subject or an important ingredient will be rated higher than one that is more generic (e.g. a general talk about GIS software).
+* Preference of "open": A submission about open data and open source software will be preferred over one that deals with proprietary data or proprietary software and closed platforms.
+* Preference of innovation: A submission about something new, or something not discussed at previous conferences, will be preferred over one that discusses more widely known issues (exception: OSM Basics).
+* We are hoping for talks from a multitude of speakers and hence we would prefer accepting a talk from a "new" speaker over accepting a second talk from someone who has already an accepted talk.
+* We will also try to avoid accepting too many talks from members of the same organisation.
+* We prefer talks from members of underrepresented groups.
+* We value transparency. We expect submitters to disclose affiliations and sponsors of their work.
+
+
+Sometimes we will make some changes or have suggestions:
+
+* We might ask if several speakers can merge their talks.
+* We might also ask if a change of format would be possible (for example, we might suggest the lightning talk format instead of a regular talk when we find there is not enough space in the programme for a complete talk, but it is an interesting subject).
+
+
+## Language {#language}
+
+The conference language of the State of the Map is English. All presentations shall thus be held in English. It is an important aspect of the conference that participants can interact with the speakers for questions and discussions. This restriction does not apply to Birds of a Feather sessions. They may be held in other languages, according to the preferences and needs of their participants.
+
+## Publication {#publication}
+
+Video recordings and slides of the lectures will be published under the [Creative Commons Attribution International 3.0 or later (CC BY 3.0+) license](https://creativecommons.org/licenses/by/3.0/). If you use any music or other third party media like photos during your talk, make sure it was published under a compatible license, as we might otherwise not be able to publish the video recording of your session.
+
+## Tickets {#conference-tickets}
+
+State of the Map is a non-commercial event where neither the organisers nor the speakers are being paid. Speakers have to get a conference ticket just like everyone else, as well as organise and pay their trip to the conference and their accommodation themselves. Details about the tickets will be announced later.
+
+## Programme Committee {#committee}
+
+Your submissions will be reviewed by a programme committee consisting of OpenStreetMap community members from various parts of the world.
+
+* Manfred Stock (lead programme committee, mapper, Switzerland)
+* Sarah Hoffmann (lead programme committee, developer, Germany)
+* Arun Ganesh (mapper and cartographer, India)
+* Benedicta Ohene (OSM Africa, Ghana/West Africa)
+* Christine Karch (chairwoman SotM Working Group, Germany)
+* Federica Gaspari (OSM community, Italy)
+* Feye Andal (OSM Philippines)
+* Ilya Zverev (forum moderator, Russia)
+* John Bryant (geospatial consultant & mapper, Australia)
+* Laura Mugeha (Kenya)
+* Miriam Gonzales (Geochicas, Mexico)
+* Satochi Iida (OSMF Japan, Japan)
+* Sawan Shariar (OSM Bangladesh & Team BHOOT, Bangladesh)
+* Séverin Menard (EOF, France, French-speaking West-African and Caribbean outreach)
+* Stefan Keller (Geometa Lab Campus Rapperswil, Eastern Switzerland University of Applied Sciences (FH OST), Switzerland)
+
+
+The programme committee is aware of possible conflict of interest situations. We try to balance that in the composition of the committee. Nevertheless, we have imposed some rules upon ourselves to handle conflict of interest situations:
+
+* We do not rate submissions from our workmates, clients or relatives.
+* We act carefully and are aware about possible conflicts (especially the situation of [horse trading](https://en.wikipedia.org/wiki/Horse_trading)). We act particularly careful in cases associated to a sponsor.
+* We communicate to other programme committee members when we are in a conflict of interest situation.
+* We report any outside attempt of influencing our decisions to the chair of the SotM Working Group.
+
+We hope this detailed "Call for Presentations" helps to increase the transparency of our programme selection process. Questions are welcome. You can reach us at the following email address: [program-sotm@openstreetmap.org](mailto:program-sotm@openstreetmap.org).
+
+## Timeline and Deadlines {#timeline_deadlines}
+
+* [18 May 2025 23:59:59 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=End%20of%20State%20of%20the%20Map%202025%20Call%20for%20Participation&iso=20250518T2359): Deadline talk, workshop and panel submissions
+* End of June 2025: End of review phase, speakers will be informed, schedule published
+* July 2025: Talk video production (test video and final video)
+* 3-5 October 2025: State of the Map
+
+## Submit your presentation {#submit}
+
+Please submit your presentation proposal to our [submission form](https://pretalx.com/sotm2025/submit).
+
+---
+
+_The SotM 2025 Programme Committee, 16 February 2025_
+


### PR DESCRIPTION
This contains the general CfP for SotM 2025. It is ready content-wise, but we might not want to merge and publish this just yet:
* At the time of this writing, the event in Pretalx is not live, yet, so the link to the submission form does not work, yet, either.
* We might want to coordinate with the academic team when we publish and advertise the call.