### PR TITLE
Extend deadline for general track submissions to 21 May

### DIFF
--- a/calls/general.md
+++ b/calls/general.md
@@ -190,8 +190,9 @@ We hope this detailed "Call for Presentations" helps to increase the transparenc
 
 ## Timeline and Deadlines {#timeline_deadlines}
 
-* [18 May 2025 23:59:59 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=End%20of%20State%20of%20the%20Map%202025%20Call%20for%20Participation&iso=20250518T2359): Deadline talk, workshop and panel submissions
-* 1 June 2025: Deadline academic talk submissions
+* ~~[18 May 2025 23:59:59 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=End%20of%20State%20of%20the%20Map%202025%20Call%20for%20Participation&iso=20250518T2359): Deadline talk, workshop and panel submissions~~
+* [21 May 2025 23:59:59 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=End%20of%20State%20of%20the%20Map%202025%20Call%20for%20Participation&iso=20250521T2359): Deadline talk, workshop and panel submissions
+* 1 June 2025: Deadline [academic talk submissions]({{site.baseurl}}/calls/osm-science)
 * End of June 2025: End of review phase, speakers will be informed, schedule published
 * July 2025: Talk video production (test video and final video)
 * 3-5 October 2025: State of the Map

--- a/calls/osm-science.md
+++ b/calls/osm-science.md
@@ -32,7 +32,7 @@ The 2019 and 2020 Academic Track resulted in a [special issue](https://www.mdpi.
 
 * <s>18 May 2025: Deadline academic talk submissions</s>
 * 1 June 2025: Deadline academic talk submissions
-* 18 May 2025: Deadline [non-acaemic talk submissions]({{site.baseurl}}/calls/general)
+* 21 May 2025: Deadline [non-academic talk submissions]({{site.baseurl}}/calls/general)
 * 1 July 2025: Notification of acceptance / rejection
 * 15 July 2025: Program announcement
 * 3-5 October 2025: OSM Science at State of the Map 2025


### PR DESCRIPTION
We've decided to extend the deadline for the general track by a few days, so this changes the relevant dates in the website.

In addition to that, it also adds a link from the general call timeline to the OSM Science call and fixes a typo in the link text of the corresponding link on the OSM Science call.